### PR TITLE
AI Orchestrator & Gateway overview dashboards

### DIFF
--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -344,7 +344,6 @@
           "links": [],
           "mappings": [],
           "min": 0,
-          "noValue": "✅",
           "unit": "short"
         },
         "overrides": []
@@ -950,6 +949,7 @@
           "links": [],
           "mappings": [],
           "min": 0,
+          "noValue": "⌛",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1154,6 +1154,7 @@
           "links": [],
           "mappings": [],
           "min": 0,
+          "noValue": "⌛",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1655,6 +1656,7 @@
           "links": [],
           "mappings": [],
           "min": 0,
+          "noValue": "⌛",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -2275,6 +2277,7 @@
           "links": [],
           "mappings": [],
           "min": 0,
+          "noValue": "⌛",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -2544,6 +2547,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 73,
+  "version": 75,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -1166,7 +1166,56 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Min"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Mean"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -2547,6 +2596,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 75,
+  "version": 76,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -644,7 +644,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__rate_interval]))",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -699,8 +699,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -769,8 +768,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -2553,6 +2551,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 79,
+  "version": 80,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -677,7 +677,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "_____\n# Worker stats\n_____",
+        "content": "_____\n# Job stats\n_____",
         "mode": "markdown"
       },
       "pluginVersion": "11.1.0",
@@ -912,7 +912,7 @@
           "refId": "audio2txt"
         }
       ],
-      "title": "Failed jobs",
+      "title": "Error origin",
       "transformations": [
         {
           "id": "labelsToFields",
@@ -1364,7 +1364,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1434,7 +1435,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1506,7 +1508,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1675,7 +1678,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1805,7 +1809,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1985,6 +1990,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 97,
+  "version": 98,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -647,6 +647,7 @@
           "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__interval]))",
           "hide": false,
           "instant": false,
+          "interval": "2m",
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
           "refId": "A"
@@ -699,7 +700,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -768,7 +770,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -945,7 +948,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1136,7 +1140,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -2539,7 +2544,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
@@ -2551,6 +2556,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 80,
+  "version": 82,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -573,7 +573,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 70,
             "gradientMode": "none",
             "hideFrom": {
@@ -583,7 +583,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "stepAfter",
-            "lineWidth": 0,
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -598,6 +598,7 @@
               "mode": "off"
             }
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -621,7 +622,6 @@
         "y": 18
       },
       "id": 23763572295,
-      "interval": "15s",
       "options": {
         "legend": {
           "calcs": [],
@@ -644,7 +644,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[2m]))",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -2563,6 +2563,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 78,
+  "version": 79,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -947,8 +947,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1139,8 +1138,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1359,8 +1357,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1429,8 +1426,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1533,8 +1529,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1677,8 +1672,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1854,8 +1848,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -2011,8 +2004,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -2154,8 +2146,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -2298,8 +2289,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -2458,7 +2448,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "2675",
           "value": "2675"
         },

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -627,7 +627,7 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -1361,8 +1361,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1431,8 +1430,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1535,8 +1533,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1679,8 +1676,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1856,8 +1852,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -2562,6 +2557,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 87,
+  "version": 88,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -571,7 +571,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "auto",
+            "axisPlacement": "right",
             "barAlignment": 0,
             "drawStyle": "bars",
             "fillOpacity": 70,
@@ -949,7 +949,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1140,7 +1141,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1359,7 +1361,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1428,7 +1431,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1497,7 +1501,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "auto",
+            "axisPlacement": "right",
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -1531,7 +1535,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1674,7 +1679,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1850,7 +1856,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -2114,7 +2121,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "auto",
+            "axisPlacement": "right",
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -2555,6 +2562,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 86,
+  "version": 87,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -622,6 +622,7 @@
         "y": 18
       },
       "id": 23763572295,
+      "maxDataPoints": 100,
       "options": {
         "legend": {
           "calcs": [],
@@ -2544,7 +2545,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -2556,6 +2557,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 82,
+  "version": 84,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -306,7 +306,7 @@
           "editorMode": "code",
           "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "A"
         }
@@ -384,7 +384,7 @@
           "editorMode": "code",
           "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "A"
         }
@@ -649,7 +649,7 @@
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "A"
         }
@@ -1030,7 +1030,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2img"
         },
@@ -1042,7 +1042,7 @@
           "editorMode": "code",
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2img"
         },
@@ -1055,7 +1055,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2vid"
         },
@@ -1068,7 +1068,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2vid"
         },
@@ -1081,7 +1081,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1000 * 60 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
         }
@@ -1220,7 +1220,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2img"
         },
@@ -1232,7 +1232,7 @@
           "editorMode": "code",
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024)",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2img"
         },
@@ -1245,7 +1245,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2vid"
         },
@@ -1258,7 +1258,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2vid"
         },
@@ -1271,7 +1271,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
         }
@@ -1364,8 +1364,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1435,8 +1434,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1508,8 +1506,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1678,8 +1675,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1809,8 +1805,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1990,6 +1985,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 98,
+  "version": 99,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -949,8 +949,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -965,7 +964,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           },
@@ -977,7 +976,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           },
@@ -989,7 +988,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -1141,8 +1140,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1157,7 +1155,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           },
@@ -1169,7 +1167,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           },
@@ -1181,7 +1179,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -1695,7 +1693,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -1867,7 +1865,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -2023,7 +2021,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -2312,7 +2310,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -2557,6 +2555,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 85,
+  "version": 86,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -278,7 +278,7 @@
               "viz": false
             }
           },
-          "decimals": 1,
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -358,9 +358,9 @@
               "viz": false
             }
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
-          "max": 1,
           "min": 0,
           "noValue": "0",
           "unit": "short"
@@ -618,6 +618,7 @@
             "fixedColor": "dark-green",
             "mode": "fixed"
           },
+          "decimals": 0,
           "mappings": [],
           "noValue": "0",
           "thresholds": {
@@ -689,6 +690,7 @@
             "fixedColor": "dark-orange",
             "mode": "fixed"
           },
+          "decimals": 0,
           "mappings": [],
           "noValue": "0",
           "thresholds": {
@@ -871,6 +873,7 @@
               "viz": false
             }
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -1358,6 +1361,7 @@
               "viz": false
             }
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -1490,6 +1494,7 @@
             "fixedColor": "dark-green",
             "mode": "fixed"
           },
+          "decimals": 0,
           "mappings": [],
           "noValue": "0",
           "thresholds": {
@@ -1561,6 +1566,7 @@
             "fixedColor": "dark-orange",
             "mode": "fixed"
           },
+          "decimals": 0,
           "mappings": [],
           "noValue": "0",
           "thresholds": {
@@ -1959,6 +1965,7 @@
             },
             "inspect": false
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -2148,6 +2155,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 117,
+  "version": 118,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -7,13 +7,6 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
-    },
-    {
-      "name": "VAR_JOB_LIVEPEER",
-      "type": "constant",
-      "label": "Job filter: Gateway",
-      "value": "",
-      "description": "Filter Gateway metrics by `job`, as set in your Prometheus client. Keep empty to apply no filtering."
     }
   ],
   "__elements": {},
@@ -997,18 +990,6 @@
                 "value": 150
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last *"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 150
-              }
-            ]
           }
         ]
       },
@@ -1124,8 +1105,7 @@
             "reducers": [
               "min",
               "mean",
-              "max",
-              "lastNotNull"
+              "max"
             ]
           }
         }
@@ -1195,18 +1175,6 @@
             "matcher": {
               "id": "byName",
               "options": "Max"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 150
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last *"
             },
             "properties": [
               {
@@ -1327,8 +1295,7 @@
             "reducers": [
               "min",
               "mean",
-              "max",
-              "lastNotNull"
+              "max"
             ]
           }
         }
@@ -2536,25 +2503,25 @@
         "type": "query"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
         "description": "Filters all Gateway metrics by this job name. Leave empty to if you don't want to filter by job name.",
         "hide": 2,
         "label": "Job filter: Gateway",
         "name": "job_livepeer",
-        "query": "${VAR_JOB_LIVEPEER}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_JOB_LIVEPEER}",
-          "text": "${VAR_JOB_LIVEPEER}",
-          "selected": false
-        },
         "options": [
           {
-            "value": "${VAR_JOB_LIVEPEER}",
-            "text": "${VAR_JOB_LIVEPEER}",
-            "selected": false
+            "selected": true,
+            "text": "",
+            "value": ""
           }
-        ]
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
       },
       {
         "current": {},
@@ -2596,6 +2563,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 76,
+  "version": 78,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -7,10 +7,22 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
     }
   ],
   "__elements": {},
   "__requires": [
+    {
+      "type": "datasource",
+      "id": "__expr__",
+      "version": "1.0.0"
+    },
     {
       "type": "grafana",
       "id": "grafana",
@@ -159,7 +171,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 2,
+          "decimals": 4,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -170,22 +182,22 @@
               }
             ]
           },
-          "unit": "currencyUSD"
+          "unit": "Eth"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "Wins"
+              "options": "B"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "short"
+                "value": "currencyUSD"
               },
               {
                 "id": "decimals",
-                "value": 0
+                "value": 2
               }
             ]
           }
@@ -213,7 +225,7 @@
           "values": false
         },
         "showPercentChange": false,
-        "textMode": "auto",
+        "textMode": "value",
         "wideLayout": true
       },
       "pluginVersion": "11.1.0",
@@ -225,12 +237,22 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[$__range])) / 1e+09 * $eth",
+          "expr": "sum(increase(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[$__range])) / 1e+09",
           "hide": false,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "eth",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A * $eth",
+          "hide": false,
+          "refId": "B",
+          "type": "math"
         }
       ],
       "title": "Ticket value sent",
@@ -256,15 +278,17 @@
               "viz": false
             }
           },
+          "decimals": 1,
           "links": [],
           "mappings": [],
           "min": 0,
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 15,
         "w": 9,
         "x": 6,
         "y": 4
@@ -320,7 +344,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "",
+      "description": "Requests that failed due to no supply being available",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -336,18 +360,20 @@
           },
           "links": [],
           "mappings": [],
+          "max": 1,
           "min": 0,
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 15,
         "w": 9,
         "x": 15,
         "y": 4
       },
-      "id": 23763572284,
+      "id": 23763572324,
       "interval": "15s",
       "options": {
         "displayLabels": [],
@@ -382,14 +408,14 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "expr": "sum by (pipeline, model_name) (\n    increase(\n        livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", error_code=~\"no orchestrators available.*\"}[$__range]\n    )\n)",
           "hide": false,
           "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Errors",
+      "title": "Missing supply",
       "transparent": true,
       "type": "piechart"
     },
@@ -504,7 +530,7 @@
         ]
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 6,
         "x": 0,
         "y": 9
@@ -531,7 +557,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24*365)/12)*1e-9 * $eth or on() vector(0)",
+          "expr": "sum((rate(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24*365)/12)*1e-9 * $eth) or on() vector(0)",
           "legendFormat": "Monthly",
           "range": true,
           "refId": "A"
@@ -542,7 +568,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))*1e-9 * $eth or on() vector(0)",
+          "expr": "sum((rate(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))*1e-9 * $eth) or on() vector(0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Daily",
@@ -553,6 +579,174 @@
       "title": "💵 Daily/Monthly Fees",
       "transparent": true,
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "id": 23763572300,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Job stats\n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 19
+      },
+      "id": 23763572320,
+      "interval": "15s",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "Sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Completed",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "Requests that failed due to no supply being available",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-orange",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 19
+      },
+      "id": 23763572323,
+      "interval": "15s",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n    increase(\n        livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", error_code=~\"no orchestrators available.*\"}[$__range]\n    )\n)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Missing supply",
+      "transparent": true,
+      "type": "stat"
     },
     {
       "datasource": {
@@ -616,10 +810,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
+        "h": 15,
         "w": 18,
         "x": 6,
-        "y": 18
+        "y": 19
       },
       "id": 23763572295,
       "maxDataPoints": 100,
@@ -664,174 +858,6 @@
         "uid": "${DS_VICTORIAMETRICS}"
       },
       "description": "",
-      "gridPos": {
-        "h": 3,
-        "w": 6,
-        "x": 0,
-        "y": 19
-      },
-      "id": 23763572300,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "_____\n# Job stats\n_____",
-        "mode": "markdown"
-      },
-      "pluginVersion": "11.1.0",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 0,
-        "y": 22
-      },
-      "id": 23763572320,
-      "interval": "15s",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
-          "hide": false,
-          "legendFormat": "Sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Completed",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-red",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 3,
-        "y": 22
-      },
-      "id": 23763572321,
-      "interval": "15s",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
-          "hide": false,
-          "legendFormat": "Sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Failed",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
-      "description": "Where did the error which caused the job to fail occur?",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -848,33 +874,23 @@
           "links": [],
           "mappings": [],
           "min": 0,
+          "noValue": "0",
           "unit": "short"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Gateway"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 11,
         "w": 6,
         "x": 0,
-        "y": 27
+        "y": 24
       },
-      "id": 23763572322,
+      "id": 23763572284,
       "interval": "15s",
       "options": {
+        "displayLabels": [],
         "legend": {
+          "calcs": [],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true,
@@ -892,8 +908,8 @@
           "values": false
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.1.0",
@@ -904,24 +920,14 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (orchestrator_address) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "expr": "sum by (pipeline, model_name) (\n    increase(\n        livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", error_code!=\"no orchestrators available within 2s timeout\", error_code!=\"no orchestrators available\"}[$__range]\n    )\n)",
           "hide": false,
-          "instant": false,
-          "legendFormat": "{{orchestrator_address}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
-          "refId": "audio2txt"
+          "refId": "A"
         }
       ],
-      "title": "Error origin",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns",
-            "valueLabel": "orchestrator_address"
-          }
-        }
-      ],
+      "title": "Errors by model",
       "transparent": true,
       "type": "piechart"
     },
@@ -930,7 +936,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "description": "What was charged for the average job:\n- upscale: from 512x512 to 1024x1024\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -998,10 +1004,10 @@
         ]
       },
       "gridPos": {
-        "h": 9,
+        "h": 11,
         "w": 9,
         "x": 6,
-        "y": 29
+        "y": 34
       },
       "id": 23763572288,
       "interval": "15s",
@@ -1084,6 +1090,19 @@
           "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"upscale\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}} | {{model_name}}",
+          "range": true,
+          "refId": "upscale"
         }
       ],
       "title": "Average cost",
@@ -1122,7 +1141,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process a second of audio",
+      "description": "Processing times, the lower the better:\n- upscale: time to upscale from 512x512 to 1024x1024\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process a second of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1190,10 +1209,10 @@
         ]
       },
       "gridPos": {
-        "h": 9,
+        "h": 11,
         "w": 9,
         "x": 15,
-        "y": 29
+        "y": 34
       },
       "id": 23763572315,
       "interval": "15s",
@@ -1274,6 +1293,19 @@
           "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"upscale\"} * 1024 * 1024)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}} | {{model_name}}",
+          "range": true,
+          "refId": "upscale"
         }
       ],
       "title": "Latency score",
@@ -1308,12 +1340,112 @@
       "type": "table"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "Where did the error which caused the job to fail occur?",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Gateway"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 35
+      },
+      "id": 23763572322,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (orchestrator_address) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", error_code!~\"no orchestrators available.*\"}[$__range]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Error origin",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns",
+            "valueLabel": "orchestrator_address"
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "piechart"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 45
       },
       "id": 23763572289,
       "panels": [],
@@ -1330,7 +1462,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 46
       },
       "id": 23763572302,
       "options": {
@@ -1364,7 +1496,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1376,7 +1509,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 42
+        "y": 49
       },
       "id": 23763572303,
       "interval": "15s",
@@ -1421,11 +1554,11 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "",
+      "description": "Requests that failed due to no supply being available",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "dark-red",
+            "fixedColor": "dark-orange",
             "mode": "fixed"
           },
           "mappings": [],
@@ -1434,7 +1567,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1446,9 +1580,9 @@
         "h": 5,
         "w": 3,
         "x": 3,
-        "y": 42
+        "y": 49
       },
-      "id": 23763572319,
+      "id": 23763572325,
       "interval": "15s",
       "options": {
         "colorMode": "background",
@@ -1475,14 +1609,14 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", model_name=\"$model\"}[$__range]))",
+          "expr": "sum(\n    increase(\n        livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", model_name=\"$model\", error_code=~\"no orchestrators available.*\"}[$__range]\n    )\n)",
           "hide": false,
-          "legendFormat": "Sum",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Failed",
+      "title": "Missing supply",
       "transparent": true,
       "type": "stat"
     },
@@ -1491,7 +1625,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "description": "What was charged for the average job:\n- upscale: from 512x512 to 1024x1024\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1506,7 +1640,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1518,7 +1653,7 @@
         "h": 5,
         "w": 3,
         "x": 6,
-        "y": 42
+        "y": 49
       },
       "id": 23763572306,
       "interval": "15s",
@@ -1547,7 +1682,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth",
+          "expr": "avg_over_time(livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", model_name=\"$model\"}[$__range]) * 1024 * 1024 * 1e-18 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Cost",
@@ -1560,7 +1695,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth",
+          "expr": "avg_over_time(livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", model_name=\"$model\"}[$__range]) * 1024 * 1024 * 1e-18 * $eth",
           "hide": false,
           "legendFormat": "Cost",
           "range": true,
@@ -1572,7 +1707,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth",
+          "expr": "avg_over_time(livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"}[$__range]) * 1024 * 1024 * 25 * 1e-18 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Cost",
@@ -1585,7 +1720,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth",
+          "expr": "avg_over_time(livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"}[$__range]) * 1024 * 1024 * 25 * 1e-18 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Cost",
@@ -1598,12 +1733,25 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"} * 1000 * 60 * 1e-18 * $eth",
+          "expr": "avg_over_time(livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"}[$__range]) * 1000 * 60 * 1e-18 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Cost",
           "range": true,
           "refId": "audio2txt"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"upscale\", model_name=\"$model\"}[$__range]) * 1024 * 1024 * 1e-18 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Cost",
+          "range": true,
+          "refId": "upscale"
         }
       ],
       "title": "Average price",
@@ -1629,7 +1777,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process 1 second of audio",
+      "description": "Processing times, the lower the better:\n- upscale: time to upscale from 512x512 to 1024x1024\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process 1 second of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1675,7 +1823,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1684,10 +1833,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 15,
+        "h": 16,
         "w": 15,
         "x": 9,
-        "y": 42
+        "y": 49
       },
       "id": 23763572316,
       "interval": "15s",
@@ -1773,6 +1922,19 @@
           "legendFormat": "{{orchestrator_address}}",
           "range": true,
           "refId": "audio2txt"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"upscale\", model_name=\"$model\"} * 1024 * 1024)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "upscale"
         }
       ],
       "title": "Latency score",
@@ -1805,7 +1967,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1827,10 +1990,10 @@
         ]
       },
       "gridPos": {
-        "h": 10,
+        "h": 11,
         "w": 9,
         "x": 0,
-        "y": 47
+        "y": 54
       },
       "id": 23763572298,
       "interval": "15s",
@@ -1860,9 +2023,9 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (orchestrator_address, error_code) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", model_name=\"$model\"}[$__range]))",
+          "expr": "sum by (orchestrator_address, error_code) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", model_name=\"$model\", error_code!~\"no orchestrators available.*\"}[$__range]))",
           "hide": false,
-          "legendFormat": "{{orchestrator_address}} `{{error_code}}`",
+          "legendFormat": "{{orchestrator_address}}: {{error_code}}",
           "range": true,
           "refId": "A"
         }
@@ -1985,6 +2148,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 99,
+  "version": 117,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -571,7 +571,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "right",
+            "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "bars",
             "fillOpacity": 70,
@@ -697,6 +697,7 @@
             "mode": "fixed"
           },
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -767,6 +768,7 @@
             "mode": "fixed"
           },
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1357,6 +1359,7 @@
             "mode": "fixed"
           },
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1372,7 +1375,7 @@
       "gridPos": {
         "h": 5,
         "w": 3,
-        "x": 1,
+        "x": 0,
         "y": 42
       },
       "id": 23763572303,
@@ -1426,6 +1429,7 @@
             "mode": "fixed"
           },
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1441,7 +1445,7 @@
       "gridPos": {
         "h": 5,
         "w": 3,
-        "x": 6,
+        "x": 3,
         "y": 42
       },
       "id": 23763572319,
@@ -1487,6 +1491,144 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
+      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-blue",
+            "mode": "fixed"
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "⌛",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent"
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 42
+      },
+      "id": 23763572306,
+      "interval": "15s",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Cost",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth",
+          "hide": false,
+          "legendFormat": "Cost",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Cost",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Cost",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"} * 1000 * 60 * 1e-18 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Cost",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Average price",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "mean"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
       "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process 1 second of audio",
       "fieldConfig": {
         "defaults": {
@@ -1499,7 +1641,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "right",
+            "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -1539,25 +1681,12 @@
           },
           "unit": "s"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "B"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "currencyUSD"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 15,
-        "w": 14,
-        "x": 10,
+        "w": 15,
+        "x": 9,
         "y": 42
       },
       "id": 23763572316,
@@ -1655,182 +1784,6 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "min": 0,
-          "noValue": "⌛",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          },
-          "unit": "string"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last *"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "currencyUSD"
-              },
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 5,
-        "x": 0,
-        "y": 47
-      },
-      "id": 23763572306,
-      "interval": "15s",
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Last *"
-          }
-        ]
-      },
-      "pluginVersion": "11.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{orchestrator_address}}",
-          "range": true,
-          "refId": "txt2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth)",
-          "hide": false,
-          "legendFormat": "{{orchestrator_address}}",
-          "range": true,
-          "refId": "img2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{orchestrator_address}}",
-          "range": true,
-          "refId": "txt2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{orchestrator_address}}",
-          "range": true,
-          "refId": "img2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"} * 1000 * 60 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{orchestrator_address}}",
-          "range": true,
-          "refId": "audio2txt"
-        }
-      ],
-      "title": "Average price",
-      "transformations": [
-        {
-          "id": "concatenate",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "0x58F90EBc1f19BDe9475556C647B0eaEE34ECe77d": "",
-              "Value 1": "Failed jobs"
-            }
-          }
-        },
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": [
-              "lastNotNull"
-            ]
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1875,8 +1828,8 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 5,
-        "x": 5,
+        "w": 9,
+        "x": 0,
         "y": 47
       },
       "id": 23763572298,
@@ -1929,506 +1882,6 @@
             "includeByName": {},
             "indexByName": {},
             "renameByName": {}
-          }
-        },
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": [
-              "lastNotNull"
-            ]
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 57
-      },
-      "id": 23763572304,
-      "panels": [],
-      "title": "Subsection: Worker specific stats",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
-      "description": "",
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 58
-      },
-      "id": 23763572305,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "_____\n# Selected node: ${worker} \n_____",
-        "mode": "markdown"
-      },
-      "pluginVersion": "11.1.0",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "min": 0,
-          "noValue": "✅",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last *"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 10,
-        "x": 0,
-        "y": 61
-      },
-      "id": 23763572323,
-      "interval": "15s",
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Last *"
-          }
-        ]
-      },
-      "pluginVersion": "11.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (pipeline, model_name, error_code) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", orchestrator_address=\"$worker\"}[$__range]))",
-          "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}: `{{error_code}}`",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Errors",
-      "transformations": [
-        {
-          "id": "concatenate",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {}
-          }
-        },
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": [
-              "lastNotNull"
-            ]
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame4\n- audio2txt: time to process 1 second of audio",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#ffffff26",
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "right",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "B"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "currencyUSD"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 15,
-        "w": 14,
-        "x": 10,
-        "y": 61
-      },
-      "id": 23763572325,
-      "interval": "15s",
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", orchestrator_address=\"$worker\" } * 1024 * 1024)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "txt2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", orchestrator_address=\"$worker\"} * 1024 * 1024)",
-          "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "img2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "txt2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "img2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", orchestrator_address=\"$worker\"} * 1)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "audio2txt"
-        }
-      ],
-      "title": "Latency score",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_VICTORIAMETRICS}"
-      },
-      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "min": 0,
-          "noValue": "⌛",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          },
-          "unit": "string"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last *"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "currencyUSD"
-              },
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 69
-      },
-      "id": 23763572324,
-      "interval": "15s",
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Last *"
-          }
-        ]
-      },
-      "pluginVersion": "11.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "txt2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 1e-18 * $eth)",
-          "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "img2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "txt2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}} {{orchestrator_address}}",
-          "range": true,
-          "refId": "img2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", orchestrator_address=\"$worker\"} * 1000 * 60  * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "audio2txt"
-        }
-      ],
-      "title": "Average cost",
-      "transformations": [
-        {
-          "id": "concatenate",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "0x58F90EBc1f19BDe9475556C647B0eaEE34ECe77d": "",
-              "Value 1": "Failed jobs"
-            }
           }
         },
         {
@@ -2516,31 +1969,6 @@
         "query": "",
         "skipUrlSync": false,
         "type": "textbox"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_VICTORIAMETRICS}"
-        },
-        "definition": "label_values(orchestrator_address)",
-        "description": "View stats for a specific worker node in the subsection down below.",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Worker",
-        "multi": false,
-        "name": "worker",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(orchestrator_address)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 5,
-        "type": "query"
       }
     ]
   },
@@ -2557,6 +1985,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 92,
+  "version": 97,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -648,7 +648,7 @@
           "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__interval]))",
           "hide": false,
           "instant": false,
-          "interval": "2m",
+          "interval": "",
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
           "refId": "A"
@@ -2557,6 +2557,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 84,
+  "version": 85,
   "weekStart": "monday"
 }

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -1,0 +1,2549 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VICTORIAMETRICS",
+      "label": "Prometheus/VictoriaMetrics",
+      "description": "Select your Prometheus-compatible data source",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_JOB_LIVEPEER",
+      "type": "constant",
+      "label": "Job filter: Gateway",
+      "value": "",
+      "description": "Filter Gateway metrics by `job`, as set in your Prometheus client. Keep empty to apply no filtering."
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.1.0"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 23763572163,
+      "panels": [],
+      "title": "Overview from ${__from:date:YYYY/MM/DD HH:mm} to ${__to:date:YYYY/MM/DD HH:mm}",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 23763572290,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Tickets\n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 18,
+        "x": 6,
+        "y": 1
+      },
+      "id": 23763572293,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Model stats\n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wins"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 23763572269,
+      "interval": "1m",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[$__range])) / 1e+09 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ticket value sent",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 9,
+        "x": 6,
+        "y": 4
+      },
+      "id": 23763572278,
+      "interval": "15s",
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Completed",
+      "transparent": true,
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "✅",
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 9,
+        "x": 15,
+        "y": 4
+      },
+      "id": 23763572284,
+      "interval": "15s",
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "transparent": true,
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "Based on the moving average with an interval of 24 hours",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 70,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Daily"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Monthly"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 23763572260,
+      "interval": "5m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "(rate(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24*365)/12)*1e-9 * $eth or on() vector(0)",
+          "legendFormat": "Monthly",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "(rate(livepeer_ticket_value_sent{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))*1e-9 * $eth or on() vector(0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Daily",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "💵 Daily/Monthly Fees",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 70,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": 600000,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 18,
+        "x": 6,
+        "y": 18
+      },
+      "id": 23763572295,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.4.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[2m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests completed",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 19
+      },
+      "id": 23763572300,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Worker stats\n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 22
+      },
+      "id": 23763572320,
+      "interval": "15s",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "Sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Completed",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 22
+      },
+      "id": 23763572321,
+      "interval": "15s",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "Sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "Where did the error which caused the job to fail occur?",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Gateway"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 6,
+        "x": 0,
+        "y": 27
+      },
+      "id": 23763572322,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (orchestrator_address) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Failed jobs",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns",
+            "valueLabel": "orchestrator_address"
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Mean"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Min"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 6,
+        "y": 29
+      },
+      "id": 23763572288,
+      "interval": "15s",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Average cost",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "min",
+              "mean",
+              "max",
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 15,
+        "y": 29
+      },
+      "id": 23763572315,
+      "interval": "15s",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024)",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Latency score",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "min",
+              "mean",
+              "max",
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 23763572289,
+      "panels": [],
+      "title": "Subsection: Model specific stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 23763572302,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Selected model: ${model} \n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 1,
+        "y": 42
+      },
+      "id": 23763572303,
+      "interval": "15s",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\", model_name=\"$model\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "Sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Completed",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 42
+      },
+      "id": 23763572319,
+      "interval": "15s",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", model_name=\"$model\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "Sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 14,
+        "x": 10,
+        "y": 42
+      },
+      "id": 23763572316,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", model_name=\"$model\"} * 1024 * 1024)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", model_name=\"$model\"} * 1024 * 1024)",
+          "hide": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"} * 1)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Latency score",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 0,
+        "y": 47
+      },
+      "id": 23763572306,
+      "interval": "15s",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Last *"
+          }
+        ]
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", model_name=\"$model\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"} * 1 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{orchestrator_address}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Average price",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "0x58F90EBc1f19BDe9475556C647B0eaEE34ECe77d": "",
+              "Value 1": "Failed jobs"
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "✅",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 5,
+        "y": 47
+      },
+      "id": 23763572298,
+      "interval": "15s",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Last *"
+          }
+        ]
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (orchestrator_address, error_code) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", model_name=\"$model\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "{{orchestrator_address}} `{{error_code}}`",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 23763572304,
+      "panels": [],
+      "title": "Subsection: Worker specific stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 23763572305,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Selected node: ${worker} \n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "✅",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 61
+      },
+      "id": 23763572323,
+      "interval": "15s",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Last *"
+          }
+        ]
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pipeline, model_name, error_code) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\", orchestrator_address=\"$worker\"}[$__range]))",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}: `{{error_code}}`",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 14,
+        "x": 10,
+        "y": 61
+      },
+      "id": 23763572325,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", orchestrator_address=\"$worker\" } * 1024 * 1024)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", orchestrator_address=\"$worker\"} * 1024 * 1024)",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", orchestrator_address=\"$worker\"} * 1)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Latency score",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 0,
+        "y": 69
+      },
+      "id": 23763572324,
+      "interval": "15s",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Last *"
+          }
+        ]
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}} {{orchestrator_address}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", orchestrator_address=\"$worker\"} * 1 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Average cost",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "0x58F90EBc1f19BDe9475556C647B0eaEE34ECe77d": "",
+              "Value 1": "Failed jobs"
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "2675",
+          "value": "2675"
+        },
+        "description": "Ethereum price in dollars $$$",
+        "hide": 0,
+        "label": "Eth price",
+        "name": "eth",
+        "options": [
+          {
+            "selected": true,
+            "text": "2675",
+            "value": "2675"
+          }
+        ],
+        "query": "2675",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_VICTORIAMETRICS}"
+        },
+        "definition": "label_values(model_name)",
+        "description": "View stats about this specific model in the subsection below",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Model",
+        "multi": false,
+        "name": "model",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(model_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "description": "Filters all Gateway metrics by this job name. Leave empty to if you don't want to filter by job name.",
+        "hide": 2,
+        "label": "Job filter: Gateway",
+        "name": "job_livepeer",
+        "query": "${VAR_JOB_LIVEPEER}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_JOB_LIVEPEER}",
+          "text": "${VAR_JOB_LIVEPEER}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_JOB_LIVEPEER}",
+            "text": "${VAR_JOB_LIVEPEER}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_VICTORIAMETRICS}"
+        },
+        "definition": "label_values(orchestrator_address)",
+        "description": "View stats for a specific worker node in the subsection down below.",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Worker",
+        "multi": false,
+        "name": "worker",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(orchestrator_address)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "30s",
+      "1h"
+    ]
+  },
+  "timezone": "",
+  "title": "Gateway AI overview",
+  "uid": "Livepeer-Gateway-AI",
+  "version": 73,
+  "weekStart": "monday"
+}

--- a/ai/gateway_overview.json
+++ b/ai/gateway_overview.json
@@ -1076,7 +1076,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1000 * 60 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1120,7 +1120,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process a second of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1240,7 +1240,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1253,7 +1253,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1487,7 +1487,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process 1 second of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1612,7 +1612,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", model_name=\"$model\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{orchestrator_address}}",
@@ -1625,7 +1625,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", model_name=\"$model\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{orchestrator_address}}",
@@ -1786,7 +1786,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"} * 1 * 1e-18 * $eth)",
+          "expr": "avg by (orchestrator_address) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", model_name=\"$model\"} * 1000 * 60 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{orchestrator_address}}",
@@ -2104,7 +2104,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame4\n- audio2txt: time to process 1 second of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2229,7 +2229,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -2242,7 +2242,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\", orchestrator_address=\"$worker\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -2403,7 +2403,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", orchestrator_address=\"$worker\"} * 1 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\", orchestrator_address=\"$worker\"} * 1000 * 60  * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -2557,6 +2557,6 @@
   "timezone": "",
   "title": "Gateway AI overview",
   "uid": "Livepeer-Gateway-AI",
-  "version": 88,
+  "version": 92,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -13,14 +13,14 @@
       "type": "constant",
       "label": "Job filter: Orchestrator",
       "value": "",
-      "description": ""
+      "description": "Filter Orchestrator metrics by `job`, as set in your Prometheus client. Keep empty to apply no filtering."
     },
     {
       "name": "VAR_JOB_GPU",
       "type": "constant",
       "label": "Job filter: GPU",
       "value": "",
-      "description": ""
+      "description": "Filter GPU metrics by `job`, as set in your Prometheus client. Keep empty to apply no filtering."
     }
   ],
   "__elements": {},

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -491,7 +491,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1000 * 60 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -499,7 +499,7 @@
           "refId": "audio2txt"
         }
       ],
-      "title": "Average income",
+      "title": "Model pricing",
       "transformations": [
         {
           "id": "concatenate",
@@ -1126,7 +1126,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process 1 second of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1252,7 +1252,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1265,7 +1265,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1857,6 +1857,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 143,
+  "version": 148,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -7,20 +7,6 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
-    },
-    {
-      "name": "VAR_JOB_LIVEPEER",
-      "type": "constant",
-      "label": "Job filter: Orchestrator",
-      "value": "",
-      "description": "Filter Orchestrator metrics by `job`, as set in your Prometheus client. Keep empty to apply no filtering."
-    },
-    {
-      "name": "VAR_JOB_GPU",
-      "type": "constant",
-      "label": "Job filter: GPU",
-      "value": "",
-      "description": "Filter GPU metrics by `job`, as set in your Prometheus client. Keep empty to apply no filtering."
     }
   ],
   "__elements": {},
@@ -1539,7 +1525,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 73
+            "y": 38
           },
           "id": 40,
           "options": {
@@ -1644,7 +1630,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 46
           },
           "id": 23763572216,
           "options": {
@@ -1748,7 +1734,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 89
+            "y": 54
           },
           "id": 23763572275,
           "options": {
@@ -1818,46 +1804,46 @@
         "type": "textbox"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
         "description": "Filters all Orchestrator metrics by this job name. Leave empty to if you don't want to filter by job name.",
         "hide": 2,
         "label": "Job filter: Orchestrator",
         "name": "job_livepeer",
-        "query": "${VAR_JOB_LIVEPEER}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_JOB_LIVEPEER}",
-          "text": "${VAR_JOB_LIVEPEER}",
-          "selected": false
-        },
         "options": [
           {
-            "value": "${VAR_JOB_LIVEPEER}",
-            "text": "${VAR_JOB_LIVEPEER}",
-            "selected": false
+            "selected": true,
+            "text": "",
+            "value": ""
           }
-        ]
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
         "description": "Filters all GPU metrics by this job name. Leave empty to if you don't want to filter by job name.",
         "hide": 2,
         "label": "Job filter: GPU",
         "name": "job_gpu",
-        "query": "${VAR_JOB_GPU}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_JOB_GPU}",
-          "text": "${VAR_JOB_GPU}",
-          "selected": false
-        },
         "options": [
           {
-            "value": "${VAR_JOB_GPU}",
-            "text": "${VAR_JOB_GPU}",
-            "selected": false
+            "selected": true,
+            "text": "",
+            "value": ""
           }
-        ]
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },
@@ -1874,6 +1860,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 130,
+  "version": 133,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -850,7 +850,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "right",
+            "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "bars",
             "fillOpacity": 70,
@@ -1138,7 +1138,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "right",
+            "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -1857,6 +1857,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 148,
+  "version": 150,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -1,0 +1,1894 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VICTORIAMETRICS",
+      "label": "Prometheus/VictoriaMetrics",
+      "description": "Select your Prometheus-compatible data source",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.1.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 2,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 23763572163,
+      "panels": [],
+      "title": "Overview from ${__from:date:YYYY/MM/DD HH:mm} to ${__to:date:YYYY/MM/DD HH:mm}",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 0,
+        "y": 1
+      },
+      "id": 23763572290,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Tickets\n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 17,
+        "x": 7,
+        "y": 1
+      },
+      "id": 23763572293,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Model stats\n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wins"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 4
+      },
+      "id": 23763572269,
+      "interval": "1m",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "increase(livepeer_winning_tickets_recv{job=\"livepeer-ai\"}[7d])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Wins",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(livepeer_ticket_value_recv{job=\"livepeer-ai\"}[7d])) / 1e+09 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Expected",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(livepeer_value_redeemed{job=\"livepeer-ai\"}[7d])) / 1e+09 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Payed",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "timeFrom": "7d",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "palette-classic"
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 17,
+        "x": 7,
+        "y": 4
+      },
+      "id": 23763572278,
+      "interval": "15s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "increase(livepeer_ai_models_requested{job=\"livepeer-ai\"}[$__range])",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Model requests",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "Based on the moving average with an interval of 24 hours",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 70,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Daily"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Monthly"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 7,
+        "x": 0,
+        "y": 11
+      },
+      "id": 23763572260,
+      "interval": "5m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "(rate(livepeer_ticket_value_recv{job=\"livepeer-ai\"}[1d])*(60*60*24*365)/12)/10^9 * $eth",
+          "legendFormat": "Monthly",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "(rate(livepeer_ticket_value_recv{job=\"livepeer-ai\"}[1d])*(60*60*24))/10^9 * $eth",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Daily",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "💵 Daily/Monthly Fees",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 17,
+        "x": 7,
+        "y": 11
+      },
+      "id": 23763572288,
+      "interval": "15s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "audio2txt"
+        }
+      ],
+      "title": "Average income",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 0,
+        "y": 17
+      },
+      "id": 23763572291,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "_____\n# Machine stats\n_____",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.1.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 70,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": 600000,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 17,
+        "x": 7,
+        "y": 18
+      },
+      "id": 23763572295,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.4.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=\"livepeer-ai\"}[2m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests completed",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "fixed"
+          },
+          "custom": {
+            "fillOpacity": 30,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": true
+          },
+          "links": [],
+          "mappings": [
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "index": 0,
+                  "text": "💤"
+                },
+                "to": 49
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 50,
+                "result": {
+                  "color": "#f2495c61",
+                  "index": 1,
+                  "text": "🔥"
+                },
+                "to": 100
+              },
+              "type": "range"
+            }
+          ],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NVIDIA GeForce RTX 4090[0]"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NVIDIA GeForce RTX 4090[1]"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 0,
+        "y": 20
+      },
+      "hideTimeOverride": true,
+      "id": 23763572282,
+      "interval": "10s",
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "utilization_gpu{job=\"gpu-ai\"}",
+          "instant": false,
+          "legendFormat": "{{gpu}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-blue",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 0,
+        "y": 25
+      },
+      "hideTimeOverride": true,
+      "id": 44,
+      "interval": "10s",
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "memory_used{job=\"gpu-ai\"}/memory_total{job=\"gpu-ai\"}",
+          "instant": true,
+          "legendFormat": "{{gpu}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "VRAM Utilization",
+      "transparent": true,
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 17,
+        "x": 7,
+        "y": 29
+      },
+      "id": 23763572294,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.4.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pipeline, model_name) (livepeer_ai_request_latency_score{job=\"livepeer-ai\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Model latency score",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "continuous-BlYlRd"
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 21,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "degree"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 30
+      },
+      "hideTimeOverride": true,
+      "id": 23763572277,
+      "interval": "10s",
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "temperature_gpu{job=\"gpu-ai\"}",
+          "instant": true,
+          "legendFormat": "{{gpu}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Temperature",
+      "transparent": true,
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-blue",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "min": 0,
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#262a2a73",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 0,
+        "y": 37
+      },
+      "hideTimeOverride": true,
+      "id": 23763572241,
+      "interval": "5s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "livepeer_versions{job=\"livepeer-ai\"}",
+          "instant": true,
+          "legendFormat": "{{livepeerversion}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Software Version",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 23763572289,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 3,
+            "w": 7,
+            "x": 1,
+            "y": 41
+          },
+          "id": 23763572296,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "_____\n# TBD\n_____",
+            "mode": "markdown"
+          },
+          "pluginVersion": "11.1.0",
+          "transparent": true,
+          "type": "text"
+        }
+      ],
+      "title": "${model} model specific",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "HLKsDmfnz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 52,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": 600000,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line+area"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "transparent"
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "NVIDIA GeForce RTX 4090[0]"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "NVIDIA GeForce RTX 4090[1]"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 42
+          },
+          "id": 40,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_VICTORIAMETRICS}"
+              },
+              "editorMode": "code",
+              "expr": "temperature_gpu{job=\"gpu-ai\"}",
+              "legendFormat": "{{gpu}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "title": "GPU Temperature",
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": 600000,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "NVIDIA GeForce RTX 4090[0]"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "NVIDIA GeForce RTX 4090[1]"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 50
+          },
+          "id": 23763572216,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_VICTORIAMETRICS}"
+              },
+              "editorMode": "code",
+              "expr": "memory_used{job=\"gpu-ai\"}/memory_total{job=\"gpu-ai\"}",
+              "legendFormat": "{{gpu}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Memory Utilization",
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": 600000,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "NVIDIA GeForce RTX 4090[0]"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "NVIDIA GeForce RTX 4090[1]"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 58
+          },
+          "id": 23763572275,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_VICTORIAMETRICS}"
+              },
+              "editorMode": "code",
+              "expr": "utilization_gpu{job=\"gpu-ai\"}",
+              "legendFormat": "{{gpu}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Total Utilization",
+          "transparent": true,
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU Memory and Temperature",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 23763572292,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#ffffff26",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 70,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 0,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": 600000,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 16,
+            "x": 0,
+            "y": 43
+          },
+          "id": 23763572284,
+          "interval": "15s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Mean",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_VICTORIAMETRICS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_request_errors{job=\"livepeer-ai\"}[1d]))",
+              "hide": false,
+              "legendFormat": "{{pipeline}}/{{model_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Errors past 24h",
+          "transparent": true,
+          "type": "timeseries"
+        }
+      ],
+      "title": "Other",
+      "type": "row"
+    }
+  ],
+  "refresh": "",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "2675",
+          "value": "2675"
+        },
+        "description": "Ethereum price in dollars $$$",
+        "hide": 0,
+        "label": "Eth price",
+        "name": "eth",
+        "options": [
+          {
+            "selected": true,
+            "text": "2675",
+            "value": "2675"
+          }
+        ],
+        "query": "2675",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_VICTORIAMETRICS}"
+        },
+        "definition": "label_values(model_name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Model",
+        "multi": false,
+        "name": "model",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(model_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "30s",
+      "1h"
+    ]
+  },
+  "timezone": "",
+  "title": "Orchestrator AI overview",
+  "uid": "Livepeer-AI",
+  "version": 79,
+  "weekStart": "monday"
+}

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -927,6 +927,7 @@
           "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__interval]))",
           "hide": false,
           "instant": false,
+          "interval": "2m",
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
           "refId": "A"
@@ -1064,7 +1065,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1170,7 +1172,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1308,7 +1311,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1390,7 +1394,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#262a2a73"
+                "color": "#262a2a73",
+                "value": null
               }
             ]
           },
@@ -1841,7 +1846,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
@@ -1853,6 +1858,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 137,
+  "version": 139,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -177,7 +177,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 3,
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -853,7 +853,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 70,
             "gradientMode": "none",
             "hideFrom": {
@@ -863,7 +863,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "stepAfter",
-            "lineWidth": 0,
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -878,6 +878,7 @@
               "mode": "off"
             }
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -901,7 +902,6 @@
         "y": 16
       },
       "id": 23763572295,
-      "interval": "15s",
       "options": {
         "legend": {
           "calcs": [],
@@ -924,7 +924,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[2m]))",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1860,6 +1860,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 133,
+  "version": 135,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -902,6 +902,7 @@
         "y": 16
       },
       "id": 23763572295,
+      "maxDataPoints": 100,
       "options": {
         "legend": {
           "calcs": [],
@@ -1846,7 +1847,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -1858,6 +1859,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 139,
+  "version": 140,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -348,7 +348,7 @@
           "editorMode": "code",
           "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "A"
         }
@@ -443,7 +443,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2img"
         },
@@ -455,7 +455,7 @@
           "editorMode": "code",
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2img"
         },
@@ -468,7 +468,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2vid"
         },
@@ -481,7 +481,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2vid"
         },
@@ -494,7 +494,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1000 * 60 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
         }
@@ -773,7 +773,7 @@
           "editorMode": "code",
           "expr": "sum by (pipeline, model_name, error_code) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}: `{{error_code}}`",
+          "legendFormat": "{{pipeline}} | {{model_name}}: `{{error_code}}`",
           "range": true,
           "refId": "A"
         }
@@ -928,7 +928,7 @@
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "A"
         }
@@ -1230,7 +1230,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2img"
         },
@@ -1242,7 +1242,7 @@
           "editorMode": "code",
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024)",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2img"
         },
@@ -1255,7 +1255,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "txt2vid"
         },
@@ -1268,7 +1268,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "img2vid"
         },
@@ -1281,7 +1281,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
         }
@@ -1857,6 +1857,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 150,
+  "version": 151,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -300,6 +300,7 @@
               "viz": false
             }
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -720,6 +721,7 @@
             },
             "inspect": false
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -1884,6 +1886,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 156,
+  "version": 157,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -310,7 +310,7 @@
       },
       "gridPos": {
         "h": 12,
-        "w": 6,
+        "w": 8,
         "x": 6,
         "y": 4
       },
@@ -408,8 +408,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 12,
-        "x": 12,
+        "w": 10,
+        "x": 14,
         "y": 4
       },
       "id": 23763572296,
@@ -740,8 +740,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 12,
-        "x": 12,
+        "w": 10,
+        "x": 14,
         "y": 10
       },
       "id": 23763572299,
@@ -1064,8 +1064,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1171,8 +1170,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1310,8 +1308,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1393,8 +1390,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#262a2a73",
-                "value": null
+                "color": "#262a2a73"
               }
             ]
           },
@@ -1512,8 +1508,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "transparent",
-                    "value": null
+                    "color": "transparent"
                   }
                 ]
               },
@@ -1613,8 +1608,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1717,8 +1711,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1784,7 +1777,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "2675",
           "value": "2675"
         },
@@ -1860,6 +1853,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 135,
+  "version": 136,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -694,7 +694,7 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "smooth",
+            "lineInterpolation": "stepAfter",
             "lineWidth": 0,
             "pointSize": 5,
             "scaleDistribution": {
@@ -710,6 +710,7 @@
               "mode": "off"
             }
           },
+          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -1765,8 +1766,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent",
-                    "value": null
+                    "color": "transparent"
                   }
                 ]
               },
@@ -1889,6 +1889,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 79,
+  "version": 80,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -7,6 +7,20 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_JOB_LIVEPEER",
+      "type": "constant",
+      "label": "Job filter: Orchestrator",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "VAR_JOB_GPU",
+      "type": "constant",
+      "label": "Job filter: GPU",
+      "value": "",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -230,7 +244,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "increase(livepeer_winning_tickets_recv{job=\"livepeer-ai\"}[7d])",
+          "expr": "increase(livepeer_winning_tickets_recv{job=~\"^.*$job_livepeer.*$\"}[7d])",
           "hide": false,
           "instant": false,
           "legendFormat": "Wins",
@@ -244,7 +258,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(livepeer_ticket_value_recv{job=\"livepeer-ai\"}[7d])) / 1e+09 * $eth",
+          "expr": "sum(increase(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[7d])) / 1e+09 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Expected",
@@ -258,7 +272,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(livepeer_value_redeemed{job=\"livepeer-ai\"}[7d])) / 1e+09 * $eth",
+          "expr": "sum(increase(livepeer_value_redeemed{job=~\"^.*$job_livepeer.*$\"}[7d])) / 1e+09 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Payed",
@@ -331,7 +345,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "increase(livepeer_ai_models_requested{job=\"livepeer-ai\"}[$__range])",
+          "expr": "increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range])",
           "hide": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
@@ -480,7 +494,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_recv{job=\"livepeer-ai\"}[1d])*(60*60*24*365)/12)/10^9 * $eth",
+          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24*365)/12)/10^9 * $eth",
           "legendFormat": "Monthly",
           "range": true,
           "refId": "A"
@@ -491,7 +505,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_recv{job=\"livepeer-ai\"}[1d])*(60*60*24))/10^9 * $eth",
+          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))/10^9 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Daily",
@@ -577,7 +591,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -590,7 +604,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
           "hide": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
@@ -602,7 +616,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -615,7 +629,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -628,7 +642,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=\"livepeer-ai\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -759,7 +773,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=\"livepeer-ai\"}[2m]))",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[2m]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -780,11 +794,11 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "#ffffff26",
-            "mode": "fixed"
+            "fixedColor": "semi-dark-blue",
+            "mode": "shades"
           },
           "custom": {
-            "fillOpacity": 30,
+            "fillOpacity": 20,
             "hideFrom": {
               "legend": false,
               "tooltip": false,
@@ -833,38 +847,7 @@
           },
           "unit": "percent"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "NVIDIA GeForce RTX 4090[0]"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "NVIDIA GeForce RTX 4090[1]"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 5,
@@ -899,7 +882,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "utilization_gpu{job=\"gpu-ai\"}",
+          "expr": "utilization_gpu{job=~\"^.*$job_gpu.*$\"}",
           "instant": false,
           "legendFormat": "{{gpu}}",
           "range": true,
@@ -918,8 +901,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "light-blue",
-            "mode": "fixed"
+            "fixedColor": "semi-dark-blue",
+            "mode": "shades"
           },
           "decimals": 0,
           "links": [],
@@ -975,7 +958,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "memory_used{job=\"gpu-ai\"}/memory_total{job=\"gpu-ai\"}",
+          "expr": "memory_used{job=~\"^.*$job_gpu.*$\"}/memory_total{job=~\"^.*$job_gpu.*$\"}",
           "instant": true,
           "legendFormat": "{{gpu}}",
           "range": false,
@@ -1080,7 +1063,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (livepeer_ai_request_latency_score{job=\"livepeer-ai\"})",
+          "expr": "sum by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1155,7 +1138,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "temperature_gpu{job=\"gpu-ai\"}",
+          "expr": "temperature_gpu{job=~\"^.*$job_gpu.*$\"}",
           "instant": true,
           "legendFormat": "{{gpu}}",
           "range": false,
@@ -1241,7 +1224,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "livepeer_versions{job=\"livepeer-ai\"}",
+          "expr": "livepeer_versions{job=~\"^.*$job_livepeer.*$\"}",
           "instant": true,
           "legendFormat": "{{livepeerversion}}",
           "range": false,
@@ -1314,7 +1297,8 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "palette-classic"
+                "fixedColor": "semi-dark-blue",
+                "mode": "shades"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -1360,38 +1344,7 @@
               },
               "unit": "celsius"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "NVIDIA GeForce RTX 4090[0]"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "semi-dark-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "NVIDIA GeForce RTX 4090[1]"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "light-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -1424,7 +1377,7 @@
                 "uid": "${DS_VICTORIAMETRICS}"
               },
               "editorMode": "code",
-              "expr": "temperature_gpu{job=\"gpu-ai\"}",
+              "expr": "temperature_gpu{job=~\"^.*$job_gpu.*$\"}",
               "legendFormat": "{{gpu}}",
               "range": true,
               "refId": "A"
@@ -1444,7 +1397,8 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "palette-classic"
+                "fixedColor": "semi-dark-blue",
+                "mode": "shades"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -1454,7 +1408,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 30,
+                "fillOpacity": 20,
                 "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
@@ -1494,38 +1448,7 @@
               },
               "unit": "percentunit"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "NVIDIA GeForce RTX 4090[0]"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "semi-dark-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "NVIDIA GeForce RTX 4090[1]"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "light-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -1558,7 +1481,7 @@
                 "uid": "${DS_VICTORIAMETRICS}"
               },
               "editorMode": "code",
-              "expr": "memory_used{job=\"gpu-ai\"}/memory_total{job=\"gpu-ai\"}",
+              "expr": "memory_used{job=~\"^.*$job_gpu.*$\"}/memory_total{job=~\"^.*$job_gpu.*$\"}",
               "legendFormat": "{{gpu}}",
               "range": true,
               "refId": "A"
@@ -1577,7 +1500,8 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "palette-classic"
+                "fixedColor": "semi-dark-blue",
+                "mode": "shades"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -1587,7 +1511,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 30,
+                "fillOpacity": 20,
                 "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
@@ -1627,38 +1551,7 @@
               },
               "unit": "percent"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "NVIDIA GeForce RTX 4090[0]"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "semi-dark-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "NVIDIA GeForce RTX 4090[1]"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "light-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 7,
@@ -1691,7 +1584,7 @@
                 "uid": "${DS_VICTORIAMETRICS}"
               },
               "editorMode": "code",
-              "expr": "utilization_gpu{job=\"gpu-ai\"}",
+              "expr": "utilization_gpu{job=~\"^.*$job_gpu.*$\"}",
               "legendFormat": "{{gpu}}",
               "range": true,
               "refId": "A"
@@ -1807,7 +1700,7 @@
                 "uid": "${DS_VICTORIAMETRICS}"
               },
               "editorMode": "code",
-              "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_request_errors{job=\"livepeer-ai\"}[1d]))",
+              "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[1d]))",
               "hide": false,
               "legendFormat": "{{pipeline}}/{{model_name}}",
               "range": true,
@@ -1873,6 +1766,48 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "description": "Filters all Orchestrator metrics by this job name. Leave empty to if you don't want to filter by job name.",
+        "hide": 2,
+        "label": "Job filter: Orchestrator",
+        "name": "job_livepeer",
+        "query": "${VAR_JOB_LIVEPEER}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_JOB_LIVEPEER}",
+          "text": "${VAR_JOB_LIVEPEER}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_JOB_LIVEPEER}",
+            "text": "${VAR_JOB_LIVEPEER}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Filters all GPU metrics by this job name. Leave empty to if you don't want to filter by job name.",
+        "hide": 2,
+        "label": "Job filter: GPU",
+        "name": "job_gpu",
+        "query": "${VAR_JOB_GPU}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_JOB_GPU}",
+          "text": "${VAR_JOB_GPU}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_JOB_GPU}",
+            "text": "${VAR_JOB_GPU}",
+            "selected": false
+          }
+        ]
       }
     ]
   },
@@ -1889,6 +1824,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 80,
+  "version": 97,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -399,7 +399,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -731,7 +731,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 150
+                "value": 100
               }
             ]
           }
@@ -1065,8 +1065,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1172,8 +1171,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               }
             ]
           },
@@ -1311,8 +1309,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1857,6 +1854,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 141,
+  "version": 142,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -850,7 +850,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "auto",
+            "axisPlacement": "right",
             "barAlignment": 0,
             "drawStyle": "bars",
             "fillOpacity": 70,
@@ -1065,7 +1065,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1137,7 +1138,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
-            "axisPlacement": "auto",
+            "axisPlacement": "right",
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -1171,7 +1172,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent"
+                "color": "transparent",
+                "value": null
               }
             ]
           },
@@ -1309,7 +1311,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1854,6 +1857,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 142,
+  "version": 143,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -362,7 +362,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "description": "What you charge for the average job:\n- upscale: from 512x512 to 1024x1024\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -497,6 +497,19 @@
           "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"upscale\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}} | {{model_name}}",
+          "range": true,
+          "refId": "upscale"
         }
       ],
       "title": "Model pricing",
@@ -666,7 +679,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"} [1d])*(60*60*24*365)/12)*1e-9 * $eth or on() vector(0)",
+          "expr": "sum((rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"} [1d])*(60*60*24*365)/12)*1e-9 * $eth) or on() vector(0)",
           "legendFormat": "Monthly",
           "range": true,
           "refId": "A"
@@ -677,7 +690,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))*1e-9 * $eth or on() vector(0)",
+          "expr": "sum((rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))*1e-9 * $eth) or on() vector(0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Daily",
@@ -1126,7 +1139,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process 1 second of audio",
+      "description": "Processing times, the lower the better:\n- upscale: time to upscale from 512x512 to 1024x1024\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate a 1024x1024 frame\n- img2vid: time to generate a 1024x1024 frame\n- audio2txt: time to process 1 second of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1215,8 +1228,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.1.0",
@@ -1284,6 +1297,19 @@
           "legendFormat": "{{pipeline}} | {{model_name}}",
           "range": true,
           "refId": "audio2txt"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"upscale\"} * 1024 * 1024)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}} | {{model_name}}",
+          "range": true,
+          "refId": "upscale"
         }
       ],
       "title": "Latency score",
@@ -1394,7 +1420,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#262a2a73"
+                "color": "#262a2a73",
+                "value": null
               }
             ]
           },
@@ -1857,6 +1884,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 151,
+  "version": 156,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -44,6 +44,12 @@
       "version": "11.1.0"
     },
     {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
@@ -244,7 +250,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "increase(livepeer_winning_tickets_recv{job=~\"^.*$job_livepeer.*$\"}[7d])",
+          "expr": "sum(increase(livepeer_winning_tickets_recv{job=~\"^.*$job_livepeer.*$\"}[7d]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Wins",
@@ -296,36 +302,39 @@
             "fixedColor": "blue",
             "mode": "palette-classic"
           },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
           "links": [],
           "mappings": [],
           "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": null
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 17,
+        "h": 10,
+        "w": 8,
         "x": 7,
         "y": 4
       },
       "id": 23763572278,
       "interval": "15s",
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -333,9 +342,10 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.1.0",
       "targets": [
@@ -345,16 +355,93 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range])",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
           "hide": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Model requests",
+      "title": "Completed",
       "transparent": true,
-      "type": "stat"
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_VICTORIAMETRICS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#ffffff26",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "noValue": "✅",
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 9,
+        "x": 15,
+        "y": 4
+      },
+      "id": 23763572284,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pipeline, model_name, error_code) (livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"})",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}: {{error_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "transparent": true,
+      "type": "piechart"
     },
     {
       "datasource": {
@@ -394,7 +481,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -494,7 +581,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24*365)/12)/10^9 * $eth",
+          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"} [1d])*(60*60*24*365)/12)*1e-9 * $eth or on() vector(0)",
           "legendFormat": "Monthly",
           "range": true,
           "refId": "A"
@@ -505,7 +592,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))/10^9 * $eth",
+          "expr": "(rate(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[1d])*(60*60*24))*1e-9 * $eth or on() vector(0)",
           "hide": false,
           "instant": false,
           "legendFormat": "Daily",
@@ -559,10 +646,10 @@
         ]
       },
       "gridPos": {
-        "h": 7,
+        "h": 5,
         "w": 17,
         "x": 7,
-        "y": 11
+        "y": 14
       },
       "id": 23763572288,
       "interval": "15s",
@@ -645,7 +732,7 @@
           "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
           "hide": false,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
           "refId": "audio2txt"
         }
@@ -724,7 +811,6 @@
               "mode": "off"
             }
           },
-          "decimals": 0,
           "links": [],
           "mappings": [],
           "min": 0,
@@ -742,10 +828,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
+        "h": 10,
         "w": 17,
         "x": 7,
-        "y": 18
+        "y": 19
       },
       "id": 23763572295,
       "interval": "15s",
@@ -974,7 +1060,7 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "",
+      "description": "An estimation per pipeline:\n- txt2img: time to generate a 1024x1024 frame\n- img2img: time to generate a 1024x1024 frame\n- txt2vid: time to generate 25 frames of 1024x1024 \n- img2vid: time to generate 25 frames of 1024x1024\n- audio2txt: time to process a minute of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -997,14 +1083,14 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
-            "spanNulls": true,
+            "showPoints": "auto",
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1025,9 +1111,22 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 11,
@@ -1035,27 +1134,26 @@
         "x": 7,
         "y": 29
       },
-      "id": 23763572294,
+      "id": 23763572296,
       "interval": "15s",
       "options": {
         "legend": {
           "calcs": [
             "min",
             "mean",
-            "max"
+            "max",
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true,
-          "sortBy": "Mean",
-          "sortDesc": true
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "8.4.0-pre",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -1063,15 +1161,66 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\"})",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
-          "refId": "A"
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024)",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_latency_score{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "audio2txt"
         }
       ],
-      "title": "Model latency score",
+      "title": "Latency score",
       "transparent": true,
       "type": "timeseries"
     },
@@ -1237,46 +1386,6 @@
     },
     {
       "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 40
-      },
-      "id": 23763572289,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "description": "",
-          "gridPos": {
-            "h": 3,
-            "w": 7,
-            "x": 1,
-            "y": 41
-          },
-          "id": 23763572296,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "_____\n# TBD\n_____",
-            "mode": "markdown"
-          },
-          "pluginVersion": "11.1.0",
-          "transparent": true,
-          "type": "text"
-        }
-      ],
-      "title": "${model} model specific",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "HLKsDmfnz"
@@ -1285,7 +1394,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 40
       },
       "id": 52,
       "panels": [
@@ -1350,7 +1459,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 50
           },
           "id": 40,
           "options": {
@@ -1454,7 +1563,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 50
+            "y": 58
           },
           "id": 23763572216,
           "options": {
@@ -1557,7 +1666,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 58
+            "y": 66
           },
           "id": 23763572275,
           "options": {
@@ -1595,128 +1704,11 @@
           "type": "timeseries"
         }
       ],
-      "title": "GPU Memory and Temperature",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 42
-      },
-      "id": 23763572292,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "#ffffff26",
-                "mode": "fixed"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 70,
-                "gradientMode": "hue",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 0,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": 600000,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "links": [],
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "transparent"
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 16,
-            "x": 0,
-            "y": 43
-          },
-          "id": 23763572284,
-          "interval": "15s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "sortBy": "Mean",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_VICTORIAMETRICS}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[1d]))",
-              "hide": false,
-              "legendFormat": "{{pipeline}}/{{model_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Errors past 24h",
-          "transparent": true,
-          "type": "timeseries"
-        }
-      ],
-      "title": "Other",
+      "title": "Subsection: GPU Memory and Temperature",
       "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "revision": 1,
   "schemaVersion": 39,
   "tags": [],
@@ -1724,7 +1716,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "2675",
           "value": "2675"
         },
@@ -1742,30 +1734,6 @@
         "query": "2675",
         "skipUrlSync": false,
         "type": "textbox"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_VICTORIAMETRICS}"
-        },
-        "definition": "label_values(model_name)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Model",
-        "multi": false,
-        "name": "model",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(model_name)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
       },
       {
         "description": "Filters all Orchestrator metrics by this job name. Leave empty to if you don't want to filter by job name.",
@@ -1824,6 +1792,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 97,
+  "version": 121,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -69,6 +69,12 @@
     },
     {
       "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
       "id": "text",
       "name": "Text",
       "version": ""
@@ -130,7 +136,7 @@
       "description": "",
       "gridPos": {
         "h": 3,
-        "w": 7,
+        "w": 6,
         "x": 0,
         "y": 1
       },
@@ -156,8 +162,8 @@
       "description": "",
       "gridPos": {
         "h": 3,
-        "w": 17,
-        "x": 7,
+        "w": 18,
+        "x": 6,
         "y": 1
       },
       "id": 23763572293,
@@ -218,8 +224,8 @@
         ]
       },
       "gridPos": {
-        "h": 7,
-        "w": 7,
+        "h": 5,
+        "w": 6,
         "x": 0,
         "y": 4
       },
@@ -317,9 +323,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 8,
-        "x": 7,
+        "h": 12,
+        "w": 6,
+        "x": 6,
         "y": 4
       },
       "id": 23763572278,
@@ -371,58 +377,75 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "",
+      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "#ffffff26",
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
           },
           "links": [],
           "mappings": [],
           "min": 0,
-          "noValue": "✅",
-          "unit": "short"
+          "noValue": "⌛",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 10,
-        "w": 9,
-        "x": 15,
+        "h": 6,
+        "w": 12,
+        "x": 12,
         "y": 4
       },
-      "id": 23763572284,
+      "id": 23763572296,
       "interval": "15s",
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
           "fields": "",
-          "values": false
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Last *"
+          }
+        ]
       },
       "pluginVersion": "11.1.0",
       "targets": [
@@ -432,16 +455,93 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name, error_code) (livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"})",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
           "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}: {{error_code}}",
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
-          "refId": "A"
+          "refId": "txt2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "hide": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2img"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "txt2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "img2vid"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_VICTORIAMETRICS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "range": true,
+          "refId": "audio2txt"
         }
       ],
-      "title": "Errors",
+      "title": "Average income",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
       "transparent": true,
-      "type": "piechart"
+      "type": "table"
     },
     {
       "datasource": {
@@ -555,9 +655,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 7,
+        "w": 6,
         "x": 0,
-        "y": 11
+        "y": 9
       },
       "id": 23763572260,
       "interval": "5m",
@@ -609,16 +709,23 @@
         "type": "prometheus",
         "uid": "${DS_VICTORIAMETRICS}"
       },
-      "description": "An estimation per pipeline:\n- txt2img: per 1024x1024 frame\n- img2img: per 1024x1024 frame\n- txt2vid: per 25 frames of 1024x1024 \n- img2vid: per 25 frames of 1024x1024\n- audio2txt: per minute of audio",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "#ffffff26",
-            "mode": "palette-classic"
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
           },
           "links": [],
           "mappings": [],
           "min": 0,
+          "noValue": "✅",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -628,47 +735,48 @@
               }
             ]
           },
-          "unit": "currencyUSD"
+          "unit": "short"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "B"
+              "options": "Last *"
             },
             "properties": [
               {
-                "id": "unit",
-                "value": "currencyUSD"
+                "id": "custom.width",
+                "value": 150
               }
             ]
           }
         ]
       },
       "gridPos": {
-        "h": 5,
-        "w": 17,
-        "x": 7,
-        "y": 14
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 10
       },
-      "id": 23763572288,
+      "id": 23763572299,
       "interval": "15s",
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
           "fields": "",
-          "values": false
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Last *"
+          }
+        ]
       },
       "pluginVersion": "11.1.0",
       "targets": [
@@ -678,68 +786,41 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
+          "expr": "sum by (pipeline, model_name, error_code) (increase(livepeer_ai_request_errors{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
           "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
+          "legendFormat": "{{pipeline}}/{{model_name}}: `{{error_code}}`",
           "range": true,
-          "refId": "txt2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-image\"} * 1024 * 1024 * 1e-18 * $eth)",
-          "hide": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "img2img"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"text-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "txt2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"image-to-video\"} * 1024 * 1024 * 25 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "img2vid"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_VICTORIAMETRICS}"
-          },
-          "editorMode": "code",
-          "expr": "avg by (pipeline, model_name) (livepeer_ai_request_price{job=~\"^.*$job_livepeer.*$\", pipeline=\"audio-to-text\"} * 1 * 1e-18 * $eth)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{pipeline}}/{{model_name}}",
-          "range": true,
-          "refId": "audio2txt"
+          "refId": "A"
         }
       ],
-      "title": "Average income",
+      "title": "Errors",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
       "transparent": true,
-      "type": "stat"
+      "type": "table"
     },
     {
       "datasource": {
@@ -749,9 +830,9 @@
       "description": "",
       "gridPos": {
         "h": 3,
-        "w": 7,
+        "w": 6,
         "x": 0,
-        "y": 17
+        "y": 15
       },
       "id": 23763572291,
       "options": {
@@ -829,18 +910,16 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 17,
-        "x": 7,
-        "y": 19
+        "w": 18,
+        "x": 6,
+        "y": 16
       },
       "id": 23763572295,
       "interval": "15s",
       "options": {
         "legend": {
-          "calcs": [
-            "mean"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
@@ -937,9 +1016,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 7,
+        "w": 6,
         "x": 0,
-        "y": 20
+        "y": 18
       },
       "hideTimeOverride": true,
       "id": 23763572282,
@@ -1010,9 +1089,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 7,
+        "w": 6,
         "x": 0,
-        "y": 25
+        "y": 23
       },
       "hideTimeOverride": true,
       "id": 44,
@@ -1130,11 +1209,11 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 17,
-        "x": 7,
-        "y": 29
+        "w": 18,
+        "x": 6,
+        "y": 26
       },
-      "id": 23763572296,
+      "id": 23763572298,
       "interval": "15s",
       "options": {
         "legend": {
@@ -1149,8 +1228,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "11.1.0",
@@ -1255,10 +1334,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 7,
+        "h": 6,
+        "w": 6,
         "x": 0,
-        "y": 30
+        "y": 28
       },
       "hideTimeOverride": true,
       "id": 23763572277,
@@ -1339,9 +1418,9 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 7,
+        "w": 6,
         "x": 0,
-        "y": 37
+        "y": 34
       },
       "hideTimeOverride": true,
       "id": 23763572241,
@@ -1394,7 +1473,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 37
       },
       "id": 52,
       "panels": [
@@ -1447,7 +1526,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": null
                   }
                 ]
               },
@@ -1459,7 +1539,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 50
+            "y": 73
           },
           "id": 40,
           "options": {
@@ -1547,7 +1627,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1563,7 +1644,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 58
+            "y": 81
           },
           "id": 23763572216,
           "options": {
@@ -1650,7 +1731,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1666,7 +1748,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 66
+            "y": 89
           },
           "id": 23763572275,
           "options": {
@@ -1792,6 +1874,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 121,
+  "version": 130,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -242,7 +242,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(livepeer_winning_tickets_recv{job=~\"^.*$job_livepeer.*$\"}[7d]))",
+          "expr": "sum(increase(livepeer_winning_tickets_recv{job=~\"^.*$job_livepeer.*$\"}[$__range]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Wins",
@@ -256,7 +256,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[7d])) / 1e+09 * $eth",
+          "expr": "sum(increase(livepeer_ticket_value_recv{job=~\"^.*$job_livepeer.*$\"}[$__range])) / 1e+09 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Expected",
@@ -270,7 +270,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(livepeer_value_redeemed{job=~\"^.*$job_livepeer.*$\"}[7d])) / 1e+09 * $eth",
+          "expr": "sum(increase(livepeer_value_redeemed{job=~\"^.*$job_livepeer.*$\"}[$__range])) / 1e+09 * $eth",
           "hide": false,
           "instant": false,
           "legendFormat": "Payed",
@@ -278,7 +278,6 @@
           "refId": "B"
         }
       ],
-      "timeFrom": "7d",
       "transparent": true,
       "type": "stat"
     },
@@ -1859,6 +1858,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 140,
+  "version": 141,
   "weekStart": "monday"
 }

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -927,7 +927,7 @@
           "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__interval]))",
           "hide": false,
           "instant": false,
-          "interval": "2m",
+          "interval": "",
           "legendFormat": "{{pipeline}}/{{model_name}}",
           "range": true,
           "refId": "A"
@@ -1394,8 +1394,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#262a2a73",
-                "value": null
+                "color": "#262a2a73"
               }
             ]
           },

--- a/ai/orchestrator_overview.json
+++ b/ai/orchestrator_overview.json
@@ -924,7 +924,7 @@
             "uid": "${DS_VICTORIAMETRICS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__rate_interval]))",
+          "expr": "sum by (pipeline, model_name) (increase(livepeer_ai_models_requested{job=~\"^.*$job_livepeer.*$\"}[$__interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pipeline}}/{{model_name}}",
@@ -1853,6 +1853,6 @@
   "timezone": "",
   "title": "Orchestrator AI overview",
   "uid": "Livepeer-AI",
-  "version": 136,
+  "version": 137,
   "weekStart": "monday"
 }


### PR DESCRIPTION
This PR adds Grafana dashboards for AI node operators.
The Gateway dashboard provides a general overview, model-specific subsection and worker-specific subsection
The Orchestrator dashboard provides a machine overview, ticket overview and model/jobs overview.

These panels can be the basis for a follow-up bounty - for node operators want to see more metrics or want to have GPU metrics integrated in `go-livepeer`